### PR TITLE
Update "locale" option properly

### DIFF
--- a/src/js/tempusdominus-core.js
+++ b/src/js/tempusdominus-core.js
@@ -1117,6 +1117,8 @@ const DateTimePicker = (($, moment) => {
                 throw new TypeError(`locale() locale ${locale} is not loaded from moment locales!`);
             }
 
+            this._options.locale = locale;
+
             for (let i = 0; i < this._dates.length; i++) {
                 this._dates[i].locale(this._options.locale);
             }


### PR DESCRIPTION
This fixes #4 and tempusdominus/bootstrap-4#90 by properly set "locale" option.

Using `$('#datetimepicker').datetimepicker('locale', 'de')` e.g. it will now properly change the language.