### PR TITLE
fix MinViewModeNumber when multiple datetimepicker on same page with different MinViewModeNumber

### DIFF
--- a/src/js/tempusdominus-core.js
+++ b/src/js/tempusdominus-core.js
@@ -78,8 +78,7 @@ const DateTimePicker = (($, moment) => {
         keyState = {},
         keyPressHandled = {};
 
-    let MinViewModeNumber = 0,
-        Default = {
+    let Default = {
             timeZone: '',
             format: false,
             dayViewHeaderFormat: 'MMMM YYYY',
@@ -594,7 +593,7 @@ const DateTimePicker = (($, moment) => {
                 return;
             }
             if (dir) {
-                this.currentViewMode = Math.max(MinViewModeNumber, Math.min(3, this.currentViewMode + dir));
+                this.currentViewMode = Math.max(this.MinViewModeNumber, Math.min(3, this.currentViewMode + dir));
             }
             this.widget.find('.datepicker > div').hide().filter(`.datepicker-${DatePickerModes[this.currentViewMode].CLASS_NAME}`).show();
         }
@@ -767,16 +766,16 @@ const DateTimePicker = (($, moment) => {
             this.use24Hours = this.actualFormat.toLowerCase().indexOf('a') < 1 && this.actualFormat.replace(/\[.*?]/g, '').indexOf('h') < 1;
 
             if (this._isEnabled('y')) {
-                MinViewModeNumber = 2;
+                this.MinViewModeNumber = 2;
             }
             if (this._isEnabled('M')) {
-                MinViewModeNumber = 1;
+                this.MinViewModeNumber = 1;
             }
             if (this._isEnabled('d')) {
-                MinViewModeNumber = 0;
+                this.MinViewModeNumber = 0;
             }
 
-            this.currentViewMode = Math.max(MinViewModeNumber, this.currentViewMode);
+            this.currentViewMode = Math.max(this.MinViewModeNumber, this.currentViewMode);
 
             if (!this.unset) {
                 this._setValue(this._dates[0], 0);

--- a/src/js/tempusdominus-core.js
+++ b/src/js/tempusdominus-core.js
@@ -312,6 +312,7 @@ const DateTimePicker = (($, moment) => {
             this.actualFormat = null;
             this.parseFormats = null;
             this.currentViewMode = null;
+            this.MinViewModeNumber = 0;
 
             this._int();
         }
@@ -350,13 +351,6 @@ const DateTimePicker = (($, moment) => {
 
         static get ViewModes() {
             return ViewModes;
-        }
-
-        /**
-         * @return {number}
-         */
-        static get MinViewModeNumber() {
-            return MinViewModeNumber;
         }
 
         static get Event() {
@@ -1248,7 +1242,7 @@ const DateTimePicker = (($, moment) => {
             }
 
             this._options.viewMode = viewMode;
-            this.currentViewMode = Math.max(DateTimePicker.ViewModes.indexOf(viewMode) - 1, DateTimePicker.MinViewModeNumber);
+            this.currentViewMode = Math.max(DateTimePicker.ViewModes.indexOf(viewMode) - 1, this.MinViewModeNumber);
 
             this._showMode();
         }


### PR DESCRIPTION
Hello,

This PR should fix this issue i had: https://github.com/tempusdominus/bootstrap-4/issues/133

This PR is linked to another PR in the bootstrap-4 repo: https://github.com/tempusdominus/bootstrap-4/pull/166

It fixes the bug when using multiple datetimepicker on the same page with different MinViewModeNumber.