### PR TITLE
Fix event filtering

### DIFF
--- a/src/js/tempusdominus-core.js
+++ b/src/js/tempusdominus-core.js
@@ -571,7 +571,7 @@ const DateTimePicker = (($, moment) => {
         }
 
         _notifyEvent(e) {
-            if ((e.type === DateTimePicker.Event.CHANGE && e.date && e.date.isSame(e.oldDate)) || !e.date && !e.oldDate) {
+            if ((e.type === DateTimePicker.Event.CHANGE && (e.date && e.date.isSame(e.oldDate)) || !e.date && !e.oldDate)) {
                 return;
             }
             this._element.trigger(e);


### PR DESCRIPTION
This logic changed in https://github.com/tempusdominus/core/commit/e39f594dfa993e38039a21cd4259e21d30c2d10a. It broke the `show.datetimepicker` event as reported in https://github.com/tempusdominus/bootstrap-4/issues/190.