### PR TITLE
Fixed wrong dependency in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require": {
     "robloach/component-installer": "*",
     "components/jquery": ">=3.0.0",
-    "moment": ">=2.10.5"
+    "moment/moment": ">=2.10.5"
   },
   "extra": {
     "component": {


### PR DESCRIPTION
The package "moment" is not existing in composer. This is preventing installing tempusdominus via composer.
 The real name of the package is "moment/moment" (like in tempusdominus bootstrap4's composer.json).