### PR TITLE
Add dateViewBreakPoint and timeViewBreakPoint

### DIFF
--- a/src/js/tempusdominus-core.js
+++ b/src/js/tempusdominus-core.js
@@ -82,6 +82,8 @@ const DateTimePicker = (($, moment) => {
         timeZone: '',
         format: false,
         dayViewHeaderFormat: 'MMMM YYYY',
+        dateViewBreakPoint: 'col',
+        timeViewBreakPoint: 'col',
         extraFormats: false,
         stepping: 1,
         minDate: false,
@@ -900,6 +902,30 @@ const DateTimePicker = (($, moment) => {
             }
 
             this._options.dayViewHeaderFormat = newFormat;
+        }
+
+        dateViewBreakPoint(newBreakPoint) {
+            if (arguments.length === 0) {
+                return this._options.dateViewBreakPoint;
+            }
+
+            if (typeof newBreakPoint !== 'string') {
+                throw new TypeError('dateViewBreakPoint() expects a string parameter');
+            }
+
+            this._options.dateViewBreakPoint = newBreakPoint;
+        }
+
+        timeViewBreakPoint(newBreakPoint) {
+            if (arguments.length === 0) {
+                return this._options.timeViewBreakPoint;
+            }
+
+            if (typeof newBreakPoint !== 'string') {
+                throw new TypeError('timeViewBreakPoint() expects a string parameter');
+            }
+
+            this._options.timeViewBreakPoint = newBreakPoint;
         }
 
         extraFormats(formats) {


### PR DESCRIPTION
Allows `sideBySide` to render correctly with Bootstrap 4 while also allowing customizable breakpoints.

This is an issue I'm currently experiencing. 

**Before**
<img width="567" alt="Before" src="https://user-images.githubusercontent.com/7314701/62753095-0bc67080-ba38-11e9-8af6-aa82181dc231.png">

**After**
<img width="568" alt="After" src="https://user-images.githubusercontent.com/7314701/62753101-11bc5180-ba38-11e9-849b-d77b8e78d0a5.png">