### PR TITLE
Fix a typo in package.json for peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "moment": "^2.22.2",
     "moment-timezone": "^0.4.0"
   },
-  "peerDependenciesd": {
+  "peerDependencies": {
     "jquery": "^3.0",
     "moment": "^2.10",
     "moment-timezone": "^0.4.0"


### PR DESCRIPTION
This fixes the following `peerDependenciesd` typo in `package.json`:

Wrong:

```js
...
"peerDependenciesd": {
...
```

Correct:

```js
...
"peerDependencies": {
...
```