### PR TITLE
Fix for change event listener fired twice and show event listener not fired

### DIFF
--- a/src/js/tempusdominus-core.js
+++ b/src/js/tempusdominus-core.js
@@ -570,8 +570,24 @@ const DateTimePicker = (($, moment) => {
             return dataOptions;
         }
 
+        _format() {
+            return this._options.format || 'YYYY-MM-DD HH:mm';
+        }
+
+        _areSameDates(a, b) {
+            const format = this._format();
+            return a && b && (a.isSame(b) || (moment(a.format(format)).isSame(b.format(format))));
+        }
+
         _notifyEvent(e) {
-            if ((e.type === DateTimePicker.Event.CHANGE && (e.date && e.date.isSame(e.oldDate)) || !e.date && !e.oldDate)) {
+            if (
+                e.type === DateTimePicker.Event.CHANGE &&
+                (
+                    (e.date && this._areSameDates(e.date, e.oldDate))
+                    ||
+                    (!e.date && !e.oldDate)
+                )
+            ) {
                 return;
             }
             this._element.trigger(e);


### PR DESCRIPTION
This fixes the event listeners of tempusdominus.

- The `change` event was fired twice: when opening the picker with `useCurrent: true` setting the current date, as well as when closing the picker and reopening it but without changing the date (bug 🐛 ).

- The `show` event was not fired at all on subsequent re-openings of the picker
   (another bug 🐛 ).

This PR fixes these bugs. 🎉 
