### PR TITLE
Fix notifyEvent

### DIFF
--- a/src/js/tempusdominus-core.js
+++ b/src/js/tempusdominus-core.js
@@ -571,7 +571,7 @@ const DateTimePicker = (($, moment) => {
         }
 
         _notifyEvent(e) {
-            if ((e.type === DateTimePicker.Event.CHANGE && (e.date && e.date.isSame(e.oldDate)) || !e.date && !e.oldDate)) {
+            if (e.type === DateTimePicker.Event.CHANGE && ((e.date && e.date.isSame(e.oldDate)) || (!e.date && !e.oldDate))) {
                 return;
             }
             this._element.trigger(e);


### PR DESCRIPTION
I noticed the update event was not triggering, and it seems to be due to these lines:

```
if (e.type === DateTimePicker.Event.CHANGE && (e.date && e.date.isSame(e.oldDate)) || !e.date && !e.oldDate) {
    return;
}
```

If the `date` and `oldDate` properties are not set (eg. for update), then this will always return early and not trigger the event.

