### PR TITLE
Fixup: restore pre-fork-mergeback bug reporting URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "Anton Bagdatyev (Tonix)"
   ],
   "bugs": {
-    "url": "https://github.com/tonix-tuft/tempusdominus/pulls"
+    "url": "https://github.com/tempusdominus/core.git"
   },
   "scripts": {
     "watch": "./node_modules/.bin/onchange './src/js/**' -- npm run build",


### PR DESCRIPTION
While poking around to see what package version on NPM includes a bugfix, I noticed that the merge of #31 updated the `package.json` bug-reporting URL (to the value used by the forked repo).  That looks like an unintended accidental change, so this pull request restores it to the previous value.

cc @Eonasdan @tonix-tuft 